### PR TITLE
Updates gulpfile with configuration taken from file and overriden on cli

### DIFF
--- a/app/templates/gulpfile.config.json
+++ b/app/templates/gulpfile.config.json
@@ -1,0 +1,36 @@
+{
+    "paths": {
+        "src" : {
+            "css" :     "./src/scss/",
+            "js" :      "./src/js/",
+            "html":     "./src/templates/",
+            "img":      "./src/img/",
+            "fonts":    "./src/fonts/"
+        },
+        "dist": {
+            "base":     "./dist/",
+            "css" :     "./dist/css/",
+            "js" :      "./dist/js/",
+            "html":     "./dist/html/",
+            "img":      "./dist/img/",
+            "fonts":    "./dist/fonts/"
+        },
+        "deploy":       "../src/SDKTemplate/Content/"
+    },
+    "production": false,
+    "config" : {
+        "autoprefixer" : {
+            "browsers" : [
+                "ie >= 9",
+                "ie_mob >= 10",
+                "ff >= 20",
+                "chrome >= 4",
+                "safari >= 7",
+                "opera >= 23",
+                "ios >= 7",
+                "android >= 4.4",
+                "bb >= 10"
+            ]
+        }
+    }
+}

--- a/app/templates/gulpfile.config.json
+++ b/app/templates/gulpfile.config.json
@@ -15,7 +15,7 @@
             "img":      "./dist/img/",
             "fonts":    "./dist/fonts/"
         },
-        "deploy":       "../src/SDKTemplate/Content/"
+        "deploy":       "../src/SDKTemplate.Web/Content/"
     },
     "production": false,
     "config" : {

--- a/app/templates/gulpfile.config.json
+++ b/app/templates/gulpfile.config.json
@@ -17,6 +17,8 @@
         },
         "deploy":       "../src/SDKTemplate.Web/Content/"
     },
+    "path" : "",
+    "CI" : false,
     "production": false,
     "config" : {
         "autoprefixer" : {
@@ -31,6 +33,12 @@
                 "android >= 4.4",
                 "bb >= 10"
             ]
+        },
+        "psi" : {
+            "publicUrl" : "",
+            "options" : {
+                "strategy" : "mobile"
+            }
         }
     }
 }

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -182,8 +182,18 @@ gulp.task('fonts', function() {
         .pipe(gulp.dest(options.paths.dist.fonts));
 });
 
-/* Compress CSS */
-gulp.task('compress:css', function() {
+gulp.task('deploy:clean', function() {
+    return del(options.paths.deploy, { force: true });
+});
+
+gulp.task('deploy:copy', function() {
+    return gulp
+        .src(options.paths.dist.base +"**/*")
+        .pipe(gulp.dest(options.paths.deploy));
+});
+
+gulp.task('deploy', function() {
+    return runSequence('deploy:clean', 'deploy:copy');
 });
 
 /* Server with auto reload and browersync */
@@ -223,13 +233,10 @@ gulp.task('psi', function(cb) {
 /* Start task */
 gulp.task('start', ['html', 'css', 'js', 'img', 'fonts', 'serve']);
 
-/* The compress task */
-gulp.task('compress', ['compress:css']);
-
-/* Final build task including compression */
+/* Final build task */
 gulp.task('build', ['html', 'css', 'js', 'img', 'fonts']);
 
-gulp.task('ci', runSequence('clean', 'build', 'compress'));
+gulp.task('ci', runSequence('clean', 'build', 'deploy'));
 
 /* Default 'refresh' task */
 gulp.task('default', ['start']);

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -1,20 +1,26 @@
 {
-  "name": "",
+  "name": "sdktemplate",
   "private": true,
-  "devDependencies": {
+  "jshintConfig": {
+    "predef": [
+      "document",
+      "window"
+    ]
+  },
+  "dependencies": {
     "browser-sync": "^2.12.5",
-    "browserify": "^13.0.0",
-    "del": "^2.2.0",
-    "extname": "^0.1.5",
-    "gulp": "^3.8.11",
-    "gulp-autoprefixer": "^3.1.0",
-    "gulp-cache": "^0.4.4",
-    "gulp-concat": "^2.5.2",
-    "gulp-data": "^1.2.0",
-    "gulp-debug": "^2.0.1",
-    "gulp-extname": "^0.2.0",
-    "gulp-favicons": "^2.2.6",
     "gulp-front-matter": "^1.2.2",
+    "gulp-swig": "^0.8.0",
+    "http-server": "^0.9.0",
+    "psi": "^2.0.3",
+    "watchify": "^3.3.1",
+    "jshint": "^2.9.2",
+    "gulp-debug": "^2.0.1",
+    "gulp-data": "^1.2.0",
+    "gulp-uglify": "^1.5.3",
+    "run-sequence": "^1.1.0",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0",
     "gulp-header": "^1.2.2",
     "gulp-imagemin": "^2.2.1",
     "gulp-jshint": "^2.0.0",
@@ -25,28 +31,18 @@
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^2.1.1",
     "gulp-sourcemaps": "^1.6.0",
-    "gulp-swig": "^0.8.0",
-    "gulp-uglify": "^1.5.3",
-    "gulp-util": "^3.0.4",
-    "http-server": "^0.9.0",
-    "jshint": "^2.9.2",
-    "psi": "^2.0.3",
-    "run-sequence": "^1.1.0",
-    "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0",
-    "watchify": "^3.3.1"
-  },
-  "jshintConfig": {
-    "predef": [
-      "document",
-      "window"
-    ]
-  },
-  "dependencies": {
+    "gulp-extname": "^0.2.0",
+    "browserify": "^13.0.0",
+    "extname": "^0.1.5",
+    "gulp": "^3.8.11",
+    "gulp-autoprefixer": "^3.1.0",
+    "gulp-cache": "^0.4.4",
+    "gulp-concat": "^2.5.2",
     "del": "^2.2.1",
     "dom-classlist": "^1.0.1",
     "fontfaceobserver": "^1.5.4",
     "gulp-if": "^2.0.1",
+    "gulp-util": "^3.0.7",
     "load-script": "^1.0.0",
     "merge": "^1.2.0",
     "nconf": "^0.8.4",

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "", 
+  "name": "",
   "private": true,
   "devDependencies": {
     "browser-sync": "^2.12.5",
@@ -43,10 +43,13 @@
     ]
   },
   "dependencies": {
+    "del": "^2.2.1",
     "dom-classlist": "^1.0.1",
     "fontfaceobserver": "^1.5.4",
+    "gulp-if": "^2.0.1",
     "load-script": "^1.0.0",
     "merge": "^1.2.0",
+    "nconf": "^0.8.4",
     "object-assign": "^4.0.1",
     "picturefill": "^3.0.1",
     "storm-attributelist": "^0.2.0",


### PR DESCRIPTION
Introduces a `gulpfile.config.json` file:

``` json
{
    "paths": {
        "src" : {
            "css" :     "./src/scss/",
            "js" :      "./src/js/",
            "html":     "./src/templates/",
            "img":      "./src/img/",
            "fonts":    "./src/fonts/"
        },
        "dist": {
            "base":     "./dist/",
            "css" :     "./dist/css/",
            "js" :      "./dist/js/",
            "html":     "./dist/html/",
            "img":      "./dist/img/",
            "fonts":    "./dist/fonts/"
        },
        "deploy":       "../src/SDKTemplate/Content/"
    },
    "production": false,
    "config" : {
        "autoprefixer" : {
            "browsers" : [
                "ie >= 9",
                "ie_mob >= 10",
                "ff >= 20",
                "chrome >= 4",
                "safari >= 7",
                "opera >= 23",
                "ios >= 7",
                "android >= 4.4",
                "bb >= 10"
            ]
        }
    }
}
```

From which configuration for the gulpfile can be set.  Flags include `production` to denote whether to minify and uglify output as well as moving module specific config where possible.

Fixes a couple of typos also.

Still need to look at splitting the gulpfile into **dev** and **ci** build streams so a CI build can avoid the cost of downloading modules like _browserSync_.
